### PR TITLE
Fix time issues in season

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -8,6 +8,7 @@ import os
 import m3u8
 import math
 import routing
+import time
 import xbmc
 import xbmcaddon
 import xbmcplugin
@@ -562,8 +563,8 @@ def season(nid):
                 title = u"{} [Status: In Progress: {}]".format(i.title, format_time(iph.position))
         if not i.streams:
             if i.available_date:
-                a_date = time.strptime(i.available_date,'%Y-%m-%dT%H:%M:%SZ')
-                title="{} [TBA on {}]".format(title,a_date.strftime("%m/%d/%y %I:%M:%S %P"))
+                a_date = time.strptime(i.available_date, '%Y-%m-%dT%H:%M:%SZ')
+                title = "{} [TBA on {}]".format(title, time.strftime("%m/%d/%y %I:%M:%S %P", a_date))
             else:
                 title = "{} [NOT AVAILABLE]".format(title)
         li = ListItem(title)


### PR DESCRIPTION
I was getting an error that the global `time` was not defined. That was fixed by importing `time`.

Then, I got an error where there wasn't a `strftime` attribute on time. `datetime` objects have `strftime`, but `time` doesn't. I tried switching this to use `datetime` instead of `time` at first, but that led to some weird issues when calling `strptime` multiple times. So I went with using time consistently instead.

The weird `datetime.strptime` bug that the following comment points out can be addressed in a similar way, but I couldn't figure out how to actually _test_ the `episode` code out (since I have no experience with kodi plugins and I'm not a python dev)
https://github.com/scj643/plugin.video.vrv/blob/9cabd335ac1a78a3cf0c0f23e429787c64cd5e1b/addon.py#L586-L592

I don't know if there's some caveat to using `time` over `datetime`, but this seems to work for me at least.