### PR TITLE
Fix translatePath

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -13,6 +13,7 @@ import xbmc
 import xbmcaddon
 import xbmcplugin
 import xbmcgui
+import xbmcvfs
 
 from resources.lib.vrvlib import VRV
 from xbmcgui import ListItem, Dialog
@@ -28,9 +29,9 @@ _plugId = "plugin.video.vrv"
 __plugin__ = "VRV"
 __version__ = "0.2.5"
 __settings__ = xbmcaddon.Addon(id=_plugId)
-__profile__ = xbmc.translatePath(__settings__.getAddonInfo('profile'))
+__profile__ = xbmcvfs.translatePath(__settings__.getAddonInfo('profile'))
 
-__addon_path__ = xbmc.translatePath(__settings__.getAddonInfo('path'))
+__addon_path__ = xbmcvfs.translatePath(__settings__.getAddonInfo('path'))
 
 artwork_temp = os.path.join(__profile__, 'art_temp')
 sub_temp = os.path.join(__profile__, 'sub_temp')


### PR DESCRIPTION
Just a small fix that makes the addon functional on Matrix and even the current Nexus/v20 development build, after following these instructions https://forum.libreelec.tv/thread/24883-official-francetv-add-on-bug-in-le11-nightly-attributeerror-module-xbmc-has-no-a/
Error: 
```
EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--
 - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
Error Type: <class 'AttributeError'>
Error Contents: module 'xbmc' has no attribute 'translatePath'
Traceback (most recent call last):
  File "C:\Users\USERNAME\AppData\Roaming\Kodi\addons\plugin.video.vrv\addon.py", line 31, in <module>
    __profile__ = xbmc.translatePath(__settings__.getAddonInfo('profile'))
AttributeError: module 'xbmc' has no attribute 'translatePath'
-->End of Python script error report<--
```